### PR TITLE
Removing unnecessary type conversion

### DIFF
--- a/library/src/main/java/com/mikepenz/actionitembadge/library/ActionItemBadge.java
+++ b/library/src/main/java/com/mikepenz/actionitembadge/library/ActionItemBadge.java
@@ -206,7 +206,7 @@ public class ActionItemBadge {
             badgeView.setVisibility(View.GONE);
         } else {
             badgeView.setVisibility(View.VISIBLE);
-            badgeView.setText(String.valueOf(badgeCount));
+            badgeView.setText(badgeCount);
         }
 
         menu.setVisible(true);


### PR DESCRIPTION
badgeCount in last update() method is a string, so there's no need to call String.valueOf(badgeCount);